### PR TITLE
Fix encoding problems

### DIFF
--- a/download_and_parse.py
+++ b/download_and_parse.py
@@ -35,6 +35,7 @@ from java.util import Collections
 
 #josm import
 from org.openstreetmap.josm import Main
+from org.openstreetmap.josm.tools import Utils
 
 #local import
 from tools.tool import Error
@@ -83,7 +84,7 @@ class DownloadTask(SwingWorker):
                 url = URL(self.app.downloadingUrl)
                 uc = url.openConnection()
                 ins = uc.getInputStream()
-                inb = BufferedReader(InputStreamReader(ins))
+                inb = BufferedReader(InputStreamReader(ins, Utils.UTF_8))
                 builder = StringBuilder()
                 line = inb.readLine()
                 while line is not None and not self.isCancelled():


### PR DESCRIPTION
At last, the solution for Windows encoding problems is found.
Old Windows have non-UTF default encoding, so InputStreamReader gets it instead of UTF and reads incorrect data.
To emulate bug on Linux, you can run `java - Dfile.encoding=cp866 -jar josm-latest.jar`.

Could you also please fix .zip file with older version?
