### PR TITLE
Using LayerManager() in gui/NewZoneDialog.py and qat_script.py

### DIFF
--- a/error_layer.py
+++ b/error_layer.py
@@ -110,7 +110,8 @@ class ErrorLayer(GpxLayer, MouseListener):
 
     def mouseClicked(self, e):
         if(e.getButton() == MouseEvent.BUTTON1):
-            if self.mv.getActiveLayer() == self:
+            #if self.mv.getActiveLayer() == self:
+            if Main.getLayerManager().getActiveLayer() == self:
                 error = self.getNearestNode(e.getPoint())
                 if error is not None:
                     selection = (self.tool, self.view, self.check)

--- a/gui/NewZoneDialog.py
+++ b/gui/NewZoneDialog.py
@@ -360,15 +360,15 @@ class NewZoneDialog(JDialog, ActionListener, WindowListener):
         """
         layer = self.get_new_zone_editing_layer()
         if layer is not None:
-            self.app.mv.setActiveLayer(layer)
+            self.app.getLayerManager().setActiveLayer(layer)
         else:
-            Main.main.addLayer(OsmDataLayer(DataSet(), self.FAVAREALAYERNAME, None))
+            Main.getLayerManager().addLayer(OsmDataLayer(DataSet(), self.FAVAREALAYERNAME, None))
         Main.main.parent.toFront()
 
     def get_new_zone_editing_layer(self):
         """Check if the layer for editing the favourite area yet exists
         """
-        for layer in self.app.mv.getAllLayers():
+        for layer in Main.getLayerManager().getLayers():
             if layer.getName() == self.FAVAREALAYERNAME:
                 return layer
         return None
@@ -376,7 +376,7 @@ class NewZoneDialog(JDialog, ActionListener, WindowListener):
     def remove_new_zone_editing_layer(self):
         layer = self.get_new_zone_editing_layer()
         if layer is not None:
-            self.app.mv.removeLayer(layer)
+            Main.getLayerManager().removeLayer(layer)
 
     def on_zone_edited(self):
         """Read ways that delimit the favourite area and convert them to
@@ -392,7 +392,7 @@ class NewZoneDialog(JDialog, ActionListener, WindowListener):
         if mode in ("polygon", "boundary"):
             layer = self.get_new_zone_editing_layer()
             if layer is not None:
-                self.app.mv.setActiveLayer(layer)
+                Main.getLayerManager().setActiveLayer(layer)
             else:
                 if mode == "polygon":
                     msg = self.app.strings.getString("polygon_fav_layer_missing_msg")
@@ -404,7 +404,7 @@ class NewZoneDialog(JDialog, ActionListener, WindowListener):
                                               JOptionPane.WARNING_MESSAGE)
                 return
 
-            dataset = self.app.mv.editLayer.data
+            dataset = Main.getLayerManager().editLayer.data
             areaWKT = self.read_area_from_osm_ways(mode, dataset)
             if areaWKT is None:
                 print "I could not read the new favourite area."

--- a/qat_script.py
+++ b/qat_script.py
@@ -247,7 +247,7 @@ class App(PropertyChangeListener):
         """
         self.mv = self.get_mapview()
         if self.mv is None:
-            Main.main.addLayer(OsmDataLayer(DataSet(),
+            Main.getLayerManager().addLayer(OsmDataLayer(DataSet(),
                                             OsmDataLayer.createNewName(),
                                             None))
             self.mv = self.get_mapview()
@@ -591,9 +591,9 @@ class App(PropertyChangeListener):
                 removeLayers.append(layer)
         for layer in removeLayers:
             self.errorLayers.remove(layer)
-            self.mv.removeLayer(layer)
+            Main.getLayerManager().removeLayer(layer)
 
-        self.mv.addLayer(errorLayer)
+        Main.getLayerManager().addLayer(errorLayer)
         self.mv.moveLayer(errorLayer, 0)
         self.mv.addMouseListener(errorLayer)
         return errorLayer

--- a/tools/data/KeepRight/KeepRight.py
+++ b/tools/data/KeepRight/KeepRight.py
@@ -17,7 +17,7 @@ class KeepRightTool(Tool):
         self.title = "KeepRight"
 
         #Tool url
-        self.uri = "http://keepright.at/"
+        self.uri = "https://keepright.at/"
 
         #Translations
         self.isTranslated = True
@@ -141,7 +141,7 @@ class KeepRightTool(Tool):
     def download_urls(self, (zoneBbox, checks)):
         """Returns checks and urls for errors downloading
         """
-        url = "http://keepright.ipax.at/export.php?format=gpx"
+        url = self.uri + "/export.php?format=gpx"
         url += "&left=%s&right=%s&top=%s&bottom=%s" % (str(zoneBbox[0]), str(zoneBbox[2]), str(zoneBbox[3]), str(zoneBbox[1]))
         url += "&ch=0,%s" % ",".join([check.url for check in checks])
         return [{"checks": checks, "url": url}]
@@ -210,7 +210,7 @@ class KeepRightTool(Tool):
     def error_url(self, error):
         """Create a url to view an error in the web browser
         """
-        url = "http://keepright.ipax.at/report_map.php?"
+        url = self.uri + "/report_map.php?"
         url += "schema=%s" % error.errorId.split(" ")[0]
         url += "&error=%s" % error.errorId.split(" ")[1]
         return url
@@ -219,7 +219,7 @@ class KeepRightTool(Tool):
         """Tell the tool server that current error is a false
            positive
         """
-        url = "http://keepright.ipax.at/comment.php?"
+        url = self.uri + "/comment.php?"
         url += "st=ignore&"
         if len(error.other) != 0:
             #There is a comment on the error, copy it
@@ -232,7 +232,7 @@ class KeepRightTool(Tool):
     def sayBugFixed(self, error, check):
         """Tell tool server that the current error is fixed
         """
-        url = "http://keepright.ipax.at/comment.php?"
+        url = self.uri + "/comment.php?"
         url += "st=ignore_t&"
         if len(error.other) != 0:
             #There is a comment on the error, copy it


### PR DESCRIPTION
As part of the GSOC project in 2015 several _MapView_ methods were changed to use _getLayerManager()_ instead (https://josm.openstreetmap.de/ticket/12863).  This pull request makes changes necessary for _qat_script_ to work with recent versions of josm.